### PR TITLE
Update camerafollow.cs

### DIFF
--- a/Scripts/camerafollow.cs
+++ b/Scripts/camerafollow.cs
@@ -1,16 +1,17 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Collections;
 
 public class camerafollow : MonoBehaviour {
 
-	public GameObject character; 
+	public GameObject character;
+        public GameObject camerafollowobject;
 
 	// Update is called once per frame
 	void Update () {
 
-		if (character.transform.position.x > 10.308f)
+		if (character.transform.position.x > camerafollowobject.transform.position.x)
 		{
-			transform.position= new Vector3(character.transform.position.x, -1.9666f ,0f);
+			transform.position= new Vector3(character.transform.position.x,camerafollowobject.transform.position.y,camerafollowobject.transform.position.z);
 		}
 	
 	}


### PR DESCRIPTION
updated so that the x, y and z axis of the camera follow action are relative to the GameObject. Which in Unity is set to self. This way when people using the tutorial but started in a different x,y,z canvas dont get camera trouble.

Enjoying your MVA presentation :-))
